### PR TITLE
KeyboardNavigationEx

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,35 @@ Made by...
 [![Twitter James](https://img.shields.io/badge/twitter-%40James_Willock-55acee.svg?style=flat-square)](https://twitter.com/James_Willock)
 [![Twitter Bastian](https://img.shields.io/badge/twitter-%40batzendev-55acee.svg?style=flat-square)](https://twitter.com/batzendev)
 
+## KeyboardNavigationEx
+
+KeyboardNavigationEx is a helper class for a common focusing problem. The focus of an UI element itself isn't the problem. But if we use the common focusing methods, the control get the focus, but it doesn't get the focus visual style.
+
+The KeyboardNavigation class handles the visual style only if the control get the focus from a keyboard device or if the SystemParameters.KeyboardCues is true.
+
+With the KeyboardNavigationEx you can fix this in two simple ways.
+
+First in code behind:
+
+```csharp
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+        this.Loaded += (s, e) => { KeyboardNavigationEx.Focus(this.TheElementWhichShouldGetTheFocus); };
+    }
+}
+
+```
+
+Or in XAML code:
+
+```xaml
+<Button controlzex:KeyboardNavigationEx.AlwaysShowFocusVisual="True">Hey, I get the focus visual style on mouse click! />
+```
+
+![keyboardfocusex](https://cloud.githubusercontent.com/assets/658431/15276251/143b9b3e-1ae3-11e6-9fe0-dc704675ad3b.gif)
 
 ## AutoMove ToolTip
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@
     only:
       - develop
 
-  version: 2.0.1-dev
+  version: 2.1.0-dev
   configuration: Release
 
   init:
@@ -42,7 +42,7 @@
     only:
       - master
 
-  version: 2.0.1.{build}
+  version: 2.1.0.{build}
   configuration: Release
   
   # Install scripts. (runs after repo cloning)

--- a/src/ControlzEx.Showcase/app.manifest
+++ b/src/ControlzEx.Showcase/app.manifest
@@ -5,7 +5,7 @@
                 xmlns:asmv2="urn:schemas-microsoft-com:asm.v2"
                 xmlns:asmv3="urn:schemas-microsoft-com:asm.v3"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <assemblyIdentity version="2.0.1.0"
+    <assemblyIdentity version="2.1.0.0"
                       name="ControlzEx.Showcase"/>
     <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
         <security>

--- a/src/ControlzEx/ControlzEx.NET4.csproj
+++ b/src/ControlzEx/ControlzEx.NET4.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Helper\DpiHelper.cs" />
     <Compile Include="Helper\MonitorHelper.cs" />
     <Compile Include="Helper\PropertyChangeNotifier.cs" />
+    <Compile Include="KeyboardNavigationEx.cs" />
     <Compile Include="Microsoft.Windows.Shell\Standard\ComGuids.cs" />
     <Compile Include="Microsoft.Windows.Shell\Standard\Debug.cs" />
     <Compile Include="Microsoft.Windows.Shell\Standard\DoubleUtil.cs" />

--- a/src/ControlzEx/ControlzEx.NET45.csproj
+++ b/src/ControlzEx/ControlzEx.NET45.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Helper\DpiHelper.cs" />
     <Compile Include="Helper\MonitorHelper.cs" />
     <Compile Include="Helper\PropertyChangeNotifier.cs" />
+    <Compile Include="KeyboardNavigationEx.cs" />
     <Compile Include="Microsoft.Windows.Shell\Standard\ComGuids.cs" />
     <Compile Include="Microsoft.Windows.Shell\Standard\Debug.cs" />
     <Compile Include="Microsoft.Windows.Shell\Standard\DoubleUtil.cs" />

--- a/src/ControlzEx/KeyboardNavigationEx.cs
+++ b/src/ControlzEx/KeyboardNavigationEx.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Threading;
+
+namespace ControlzEx
+{
+    /// <summary>
+    /// Helper class for a common focusing problem.
+    /// The focus itself isn't the problem. If we use the common focusing methods the control get the focus
+    /// but it doesn't get the focus visual style.
+    /// The KeyboardNavigation class handles the visual style only if the control get the focus from a keyboard
+    /// device or if the SystemParameters.KeyboardCues is true.
+    /// </summary>
+    public sealed class KeyboardNavigationEx
+    {
+        private static KeyboardNavigationEx _instance;
+        //internal static bool AlwaysShowFocusVisual
+        private readonly PropertyInfo _alwaysShowFocusVisual;
+        //internal static void ShowFocusVisual()
+        private readonly MethodInfo _showFocusVisual;
+
+        // Explicit static constructor to tell C# compiler
+        // not to mark type as beforefieldinit
+        static KeyboardNavigationEx()
+        {
+        }
+
+        private KeyboardNavigationEx()
+        {
+            var type = typeof(KeyboardNavigation);
+            _alwaysShowFocusVisual = type.GetProperty("AlwaysShowFocusVisual", BindingFlags.NonPublic | BindingFlags.Static);
+            _showFocusVisual = type.GetMethod("ShowFocusVisual", BindingFlags.NonPublic | BindingFlags.Static);
+        }
+
+        /// <summary>
+        /// Gets the KeyboardNavigationEx singleton instance.
+        /// </summary>
+        internal static KeyboardNavigationEx Instance => _instance ?? (_instance = new KeyboardNavigationEx());
+
+        /// <summary>
+        /// Shows the focus visual of the current focused UI element.
+        /// Works only together with AlwaysShowFocusVisual property.
+        /// </summary>
+        internal void ShowFocusVisualInternal()
+        {
+            _showFocusVisual.Invoke(null, null);
+        }
+
+        internal bool AlwaysShowFocusVisualInternal
+        {
+            get { return (bool) _alwaysShowFocusVisual.GetValue(null, null); }
+            set { _alwaysShowFocusVisual.SetValue(null, value, null); }
+        }
+
+        /// <summary>
+        /// Focuses the specified element and shows the focus visual style.
+        /// </summary>
+        /// <param name="element">The element which will be focused.</param>
+        public static void Focus(UIElement element)
+        {
+            element?.Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
+            {
+                var keybHack = KeyboardNavigationEx.Instance;
+                var alwaysShowFocusVisual = keybHack.AlwaysShowFocusVisualInternal;
+                keybHack.AlwaysShowFocusVisualInternal = true;
+                try
+                {
+                    Keyboard.Focus(element);
+                    keybHack.ShowFocusVisualInternal();
+                }
+                finally
+                {
+                    keybHack.AlwaysShowFocusVisualInternal = alwaysShowFocusVisual;
+                }
+            }));
+        }
+
+        /// <summary>
+        /// Attached DependencyProperty for setting AlwaysShowFocusVisual for a UI element.
+        /// </summary>
+        public static readonly DependencyProperty AlwaysShowFocusVisualProperty
+            = DependencyProperty.RegisterAttached("AlwaysShowFocusVisual",
+                typeof(bool),
+                typeof(KeyboardNavigationEx),
+                new FrameworkPropertyMetadata(default(bool), AlwaysShowFocusVisualPropertyChangedCallback));
+
+        private static void AlwaysShowFocusVisualPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+        {
+            var fe = dependencyObject as UIElement;
+            if (fe != null && args.NewValue != args.OldValue)
+            {
+                fe.GotFocus -= FrameworkElementGotFocus;
+                if ((bool)args.NewValue)
+                {
+                    fe.GotFocus += FrameworkElementGotFocus;
+                }
+            }
+        }
+
+        private static void FrameworkElementGotFocus(object sender, RoutedEventArgs e)
+        {
+            KeyboardNavigationEx.Focus(sender as UIElement);
+        }
+
+        /// <summary>
+        /// Gets a the value which indicates if the UI element always show the focus visual style.
+        /// </summary>
+        [AttachedPropertyBrowsableForType(typeof(UIElement))]
+        public static bool GetAlwaysShowFocusVisual(UIElement element)
+        {
+            return (bool)element.GetValue(AlwaysShowFocusVisualProperty);
+        }
+
+        /// <summary>
+        /// Sets a the value which indicates if the UI element always show the focus visual style.
+        /// </summary>
+        public static void SetAlwaysShowFocusVisual(UIElement element, bool value)
+        {
+            element.SetValue(AlwaysShowFocusVisualProperty, value);
+        }
+    }
+}

--- a/src/GlobalAssemblyInfo.cs
+++ b/src/GlobalAssemblyInfo.cs
@@ -15,8 +15,8 @@ using System.Windows;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("2.0.1.0")]
-[assembly: AssemblyFileVersion("2.0.1.0")]
+[assembly: AssemblyVersion("2.1.0.0")]
+[assembly: AssemblyFileVersion("2.1.0.0")]
 [assembly: AssemblyInformationalVersion("SRC")]
 
 [assembly: ComVisible(false)]


### PR DESCRIPTION
KeyboardNavigationEx is a helper class for a common focusing problem. The focus of an UI element itself isn't the problem. But if we use the common focusing methods, the control get the focus, but it doesn't get the focus visual style.

The KeyboardNavigation class handles the visual style only if the control get the focus from a keyboard device or if the SystemParameters.KeyboardCues is true.

With the KeyboardNavigationEx you can fix this in two simple ways.

First in code behind:

```csharp
public partial class MainWindow : Window
{
    public MainWindow()
    {
        InitializeComponent();
        this.Loaded += (s, e) => { KeyboardNavigationEx.Focus(this.TheElementWhichShouldGetTheFocus); };
    }
}

```

Or in XAML code:

```xaml
<Button controlzex:KeyboardNavigationEx.AlwaysShowFocusVisual="True">Hey, I get the focus visual style on mouse click! />
```

![keyboardfocusex](https://cloud.githubusercontent.com/assets/658431/15276251/143b9b3e-1ae3-11e6-9fe0-dc704675ad3b.gif)
