### PR TITLE
Prevent creation of stray empty .DotSettings file

### DIFF
--- a/ControlzEx.sln.DotSettings
+++ b/ControlzEx.sln.DotSettings
@@ -11,9 +11,6 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/QualifiedUsingAtNestedScope/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=QAT/@EntryIndexedValue">QAT</s:String>
-	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=480D7749291F4B4BAC12DF9115ADE0CD/@KeyIndexDefined">True</s:Boolean>
-	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=480D7749291F4B4BAC12DF9115ADE0CD/AbsolutePath/@EntryValue">C:\DEV\OSS_Own\ControlzEx\ControlzEx.sln.DotSettings</s:String>
-	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=480D7749291F4B4BAC12DF9115ADE0CD/RelativePath/@EntryValue"></s:String>
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File480D7749291F4B4BAC12DF9115ADE0CD/@KeyIndexDefined">True</s:Boolean>
 	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File480D7749291F4B4BAC12DF9115ADE0CD/RelativePriority/@EntryValue">1</s:Double>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
When opening the solution in Visual Studio with ReSharper installed, an empty `.DotSettings` file is created at `C:\DEV\OSS_Own\ControlzEx\ControlzEx.sln.DotSettings`. This appears to be because the file erroneously tries to inject itself as another settings layer. This PR removes the lines injecting the layer.