### PR TITLE
Fix SetWindowPlacement #38

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@
       - develop
 
   environment:
-    semver: 3.0.1
+    semver: 3.0.2
 
   version: '%semver%-dev{build}'
   configuration: Release
@@ -45,7 +45,7 @@
     only:
       - master
 
-  version: 3.0.1.{build}
+  version: 3.0.2.{build}
   configuration: Release
   
   # Install scripts. (runs after repo cloning)

--- a/src/ControlzEx/Microsoft.Windows.Shell/Standard/NativeMethods.cs
+++ b/src/ControlzEx/Microsoft.Windows.Shell/Standard/NativeMethods.cs
@@ -3503,10 +3503,20 @@ namespace ControlzEx.Standard
         [DllImport("user32.dll", EntryPoint = "GetWindowLongPtr", SetLastError = true)]
         private static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, GWL nIndex);
 
+        /// <summary>
+        /// Retrieves the show state and the restored, minimized, and maximized positions of the specified window.
+        /// </summary>
+        /// <param name="hwnd">A handle to the window.</param>
+        /// <param name="lpwndpl">A pointer to the WINDOWPLACEMENT structure that receives the show state and position information.</param>
+        /// <remarks>
+        /// Before calling GetWindowPlacement, set the length member to sizeof(WINDOWPLACEMENT).
+        /// GetWindowPlacement fails if lpwndpl-> length is not set correctly.
+        /// </remarks>
+        /// <returns>If the function succeeds, the return value is nonzero. If the function fails, the return value is zero.</returns>
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         [DllImport("user32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool GetWindowPlacement(IntPtr hwnd, WINDOWPLACEMENT lpwndpl);
+        private static extern bool GetWindowPlacement(IntPtr hwnd, [In, Out] WINDOWPLACEMENT lpwndpl);
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         public static WINDOWPLACEMENT GetWindowPlacement(IntPtr hwnd)
@@ -3518,6 +3528,21 @@ namespace ControlzEx.Standard
             }
             throw new Win32Exception();
         }
+
+        /// <summary>
+        /// Sets the show state and the restored, minimized, and maximized positions of the specified window.
+        /// </summary>
+        /// <param name="hWnd">A handle to the window.</param>
+        /// <param name="lpwndpl">A pointer to a WINDOWPLACEMENT structure that specifies the new show state and window positions.</param>
+        /// <remarks>
+        /// Before calling SetWindowPlacement, set the length member of the WINDOWPLACEMENT structure to sizeof(WINDOWPLACEMENT).
+        /// SetWindowPlacement fails if the length member is not set correctly.
+        /// </remarks>
+        /// <returns>If the function succeeds, the return value is nonzero. If the function fails, the return value is zero.</returns>
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool SetWindowPlacement(IntPtr hWnd, [In] WINDOWPLACEMENT lpwndpl);
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         [DllImport("user32.dll", EntryPoint = "GetWindowRect", SetLastError = true)]

--- a/src/ControlzEx/Native/UnsafeNativeMethods.cs
+++ b/src/ControlzEx/Native/UnsafeNativeMethods.cs
@@ -59,50 +59,6 @@ namespace ControlzEx.Native
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool FreeLibrary([In] IntPtr hModule);
 
-        /// <summary>
-        /// Sets the show state and the restored, minimized, and maximized positions of the specified window.
-        /// </summary>
-        /// <param name="hWnd">
-        /// A handle to the window.
-        /// </param>
-        /// <param name="lpwndpl">
-        /// A pointer to a WINDOWPLACEMENT structure that specifies the new show state and window positions.
-        /// <para>
-        /// Before calling SetWindowPlacement, set the length member of the WINDOWPLACEMENT structure to sizeof(WINDOWPLACEMENT). SetWindowPlacement fails if the length member is not set correctly.
-        /// </para>
-        /// </param>
-        /// <returns>
-        /// If the function succeeds, the return value is nonzero.
-        /// <para>
-        /// If the function fails, the return value is zero. To get extended error information, call GetLastError.
-        /// </para>
-        /// </returns>
-        [DllImport("user32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool SetWindowPlacement(IntPtr hWnd, [In] ref WINDOWPLACEMENT lpwndpl);
-
-        /// <summary>
-        /// Retrieves the show state and the restored, minimized, and maximized positions of the specified window.
-        /// </summary>
-        /// <param name="hWnd">
-        /// A handle to the window.
-        /// </param>
-        /// <param name="lpwndpl">
-        /// A pointer to the WINDOWPLACEMENT structure that receives the show state and position information.
-        /// <para>
-        /// Before calling GetWindowPlacement, set the length member to sizeof(WINDOWPLACEMENT). GetWindowPlacement fails if lpwndpl-> length is not set correctly.
-        /// </para>
-        /// </param>
-        /// <returns>
-        /// If the function succeeds, the return value is nonzero.
-        /// <para>
-        /// If the function fails, the return value is zero. To get extended error information, call GetLastError.
-        /// </para>
-        /// </returns>
-        [DllImport("user32.dll", SetLastError = true)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        public static extern bool GetWindowPlacement(IntPtr hWnd, ref WINDOWPLACEMENT lpwndpl);
-
         [DllImportAttribute("user32.dll")]
         public static extern bool ReleaseCapture();
 


### PR DESCRIPTION
Fix SetWindowPlacement WINDOWPLACEMENT parameter which shouldn't be a ref value. Also remove GetWindowPlacement and SetWindowPlacement from UnsafeNativeMethods.

Closes #38 