### PR TITLE
Fixing CA2213

### DIFF
--- a/src/ControlzEx/Behaviors/TextBoxInputMaskBehavior.cs
+++ b/src/ControlzEx/Behaviors/TextBoxInputMaskBehavior.cs
@@ -76,6 +76,8 @@
 
             DataObject.RemovePastingHandler(AssociatedObject, Pasting);
 
+            textPropertyNotifier?.Dispose();
+
             base.OnDetaching();
         }
 


### PR DESCRIPTION
Ran into this warning while using this code on another project.

Addressing warning [CA2213: Disposable fields should be disposed](https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2213-disposable-fields-should-be-disposed?view=vs-2019)