### PR TITLE
Fix SystemCommands.ShowSystemMenu not DPI aware

### DIFF
--- a/src/ControlzEx/Microsoft.Windows.Shell/SystemCommands.cs
+++ b/src/ControlzEx/Microsoft.Windows.Shell/SystemCommands.cs
@@ -86,7 +86,8 @@ namespace ControlzEx.Windows.Shell
             var screenLocation = window.PointToScreen(mousePosition);
             e.Handled = true;
 
-            ShowSystemMenu(window, screenLocation);
+            // Location contains already DPI aware coordinates, so we don't need to do this twice
+            ShowSystemMenuPhysicalCoordinates(window, screenLocation);
         }
 
         /// <summary>Display the system menu at a specified location.</summary>


### PR DESCRIPTION
ShowSystemMenu with MouseButtonEventArgs contains already DPI aware coordinates, so we don't need to do this twice and should call ShowSystemMenuPhysicalCoordinates instead ShowSystemMenu.

Closes #95 

/cc @batzen 