### PR TITLE
The new PopupAssist allows to have a popup that follows your mouse

### DIFF
--- a/src/ControlzEx.Showcase/MainWindow.xaml
+++ b/src/ControlzEx.Showcase/MainWindow.xaml
@@ -208,6 +208,37 @@
                                             </ToolTip>
                                         </Button.ToolTip>
                                     </Button>
+
+                                    <ToggleButton x:Name="Tgl_AutoMovingPopup"
+                                                  MinWidth="100"
+                                                  Margin="4"
+                                                  Content="Show Auto Moving Popup" />
+                                    <Popup controlzEx:PopupAssist.AutoMove="True"
+                                           IsOpen="{Binding ElementName=Tgl_AutoMovingPopup, Path=IsChecked}"
+                                           Placement="Relative"
+                                           PlacementTarget="{Binding ElementName=Window}">
+                                        <Grid>
+                                            <Border Background="Gray"
+                                                    BorderBrush="Black"
+                                                    BorderThickness="1"
+                                                    Opacity="0.9"
+                                                    SnapsToDevicePixels="True" />
+                                            <StackPanel Orientation="Vertical">
+                                                <TextBlock Margin="5"
+                                                           FontSize="22"
+                                                           Foreground="WhiteSmoke"
+                                                           Text="PopupHelper AutoMove sample"
+                                                           TextOptions.TextFormattingMode="Display"
+                                                           TextOptions.TextRenderingMode="ClearType" />
+                                                <Viewbox Width="64" Height="64">
+                                                    <Canvas Width="24" Height="24">
+                                                        <Path Data="M19,10C19,11.38 16.88,12.5 15.5,12.5C14.12,12.5 12.75,11.38 12.75,10H11.25C11.25,11.38 9.88,12.5 8.5,12.5C7.12,12.5 5,11.38 5,10H4.25C4.09,10.64 4,11.31 4,12A8,8 0 0,0 12,20A8,8 0 0,0 20,12C20,11.31 19.91,10.64 19.75,10H19M12,4C9.04,4 6.45,5.61 5.07,8H18.93C17.55,5.61 14.96,4 12,4M22,12A10,10 0 0,1 12,22A10,10 0 0,1 2,12A10,10 0 0,1 12,2A10,10 0 0,1 22,12M12,17.23C10.25,17.23 8.71,16.5 7.81,15.42L9.23,14C9.68,14.72 10.75,15.23 12,15.23C13.25,15.23 14.32,14.72 14.77,14L16.19,15.42C15.29,16.5 13.75,17.23 12,17.23Z" Fill="DarkOrange" />
+                                                    </Canvas>
+                                                </Viewbox>
+                                            </StackPanel>
+                                        </Grid>
+                                    </Popup>
+
                                 </WrapPanel>
                             </GroupBox>
 

--- a/src/ControlzEx/PopupAssist.cs
+++ b/src/ControlzEx/PopupAssist.cs
@@ -1,0 +1,236 @@
+﻿using System;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+
+namespace ControlzEx
+{
+    using ControlzEx.Standard;
+
+    public static class PopupAssist
+    {
+        public static readonly DependencyProperty AutoMoveProperty
+            = DependencyProperty.RegisterAttached("AutoMove",
+                                                  typeof(bool),
+                                                  typeof(PopupAssist),
+                                                  new FrameworkPropertyMetadata(false, OnAutoMoveChanged));
+
+        /// <summary>
+        /// Indicates whether a popup should follow the mouse cursor.
+        /// </summary>
+        [AttachedPropertyBrowsableForType(typeof(Popup))]
+        public static bool GetAutoMove(Popup element)
+        {
+            return (bool)element.GetValue(AutoMoveProperty);
+        }
+
+        /// <summary>
+        /// Sets whether a popup should follow the mouse cursor.
+        /// </summary>
+        [AttachedPropertyBrowsableForType(typeof(Popup))]
+        public static void SetAutoMove(Popup element, bool value)
+        {
+            element.SetValue(AutoMoveProperty, value);
+        }
+
+        public static readonly DependencyProperty AutoMoveHorizontalOffsetProperty
+            = DependencyProperty.RegisterAttached("AutoMoveHorizontalOffset",
+                                                  typeof(double),
+                                                  typeof(Popup),
+                                                  new FrameworkPropertyMetadata(16d));
+
+        /// <summary>
+        /// Gets the horizontal offset for the relative placement of the Popup.
+        /// </summary>
+        [AttachedPropertyBrowsableForType(typeof(Popup))]
+        public static double GetAutoMoveHorizontalOffset(Popup element)
+        {
+            return (double)element.GetValue(AutoMoveHorizontalOffsetProperty);
+        }
+
+        /// <summary>
+        /// Sets the horizontal offset for the relative placement of the Popup.
+        /// </summary>
+        [AttachedPropertyBrowsableForType(typeof(Popup))]
+        public static void SetAutoMoveHorizontalOffset(Popup element, double value)
+        {
+            element.SetValue(AutoMoveHorizontalOffsetProperty, value);
+        }
+
+        public static readonly DependencyProperty AutoMoveVerticalOffsetProperty
+            = DependencyProperty.RegisterAttached("AutoMoveVerticalOffset",
+                                                  typeof(double),
+                                                  typeof(PopupAssist),
+                                                  new FrameworkPropertyMetadata(16d));
+
+        /// <summary>
+        /// Gets the vertical offset for the relative placement of the Popup.
+        /// </summary>
+        [AttachedPropertyBrowsableForType(typeof(Popup))]
+        public static double GetAutoMoveVerticalOffset(Popup element)
+        {
+            return (double)element.GetValue(AutoMoveVerticalOffsetProperty);
+        }
+
+        /// <summary>
+        /// Sets the vertical offset for the relative placement of the Popup.
+        /// </summary>
+        [AttachedPropertyBrowsableForType(typeof(Popup))]
+        public static void SetAutoMoveVerticalOffset(Popup element, double value)
+        {
+            element.SetValue(AutoMoveVerticalOffsetProperty, value);
+        }
+
+
+        // This private attached Property is needed because Popup has no relation to its Target.
+        static readonly DependencyProperty AutoMovingPopupProperty
+            = DependencyProperty.RegisterAttached("AutoMovingPopup",
+                                                  typeof(Popup),
+                                                  typeof(PopupAssist),
+                                                  new FrameworkPropertyMetadata(null));
+
+        /// <summary>
+        /// Gets the Popup that should be Automoved
+        /// </summary>
+        static Popup GetAutoMovingPopup(FrameworkElement element)
+        {
+            return (Popup)element.GetValue(AutoMovingPopupProperty);
+        }
+
+        /// <summary>
+        /// Sets the Popup that should be Automoved
+        /// </summary>
+        static void SetAutoMovingPopup(FrameworkElement element, Popup value)
+        {
+            element.SetValue(AutoMovingPopupProperty, value);
+        }
+
+
+
+        private static void OnAutoMoveChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs eventArgs)
+        {
+            var popup = (Popup)dependencyObject;
+            if (eventArgs.OldValue != eventArgs.NewValue && eventArgs.NewValue != null)
+            {
+                var autoMove = (bool)eventArgs.NewValue;
+                if (autoMove)
+                {
+                    popup.Opened += Popup_Opened;
+                    popup.Closed += Popup_Closed;
+                    popup.PlacementTarget?.SetCurrentValue(AutoMovingPopupProperty, popup);
+                }
+                else
+                {
+                    popup.Opened -= Popup_Opened;
+                    popup.Closed -= Popup_Closed;
+                    popup.PlacementTarget?.SetCurrentValue(AutoMovingPopupProperty, null);
+                }
+            }
+        }
+
+        private static void Popup_Opened(object sender, EventArgs e)
+        {
+            var popup = (Popup)sender;
+            if (popup.PlacementTarget is FrameworkElement target)
+            {
+                // move the Popup on opening to the correct position
+                MovePopup(target, popup);
+                target.MouseMove += PopupTargetPreviewMouseMove;
+                Debug.WriteLine(">>popup opened");
+            }
+        }
+
+        private static void Popup_Closed(object sender, EventArgs e)
+        {
+            var popup = (Popup)sender;
+            if (popup.PlacementTarget is FrameworkElement target)
+            {
+                target.MouseMove -= PopupTargetPreviewMouseMove;
+                Debug.WriteLine(">>popup closed");
+            }
+        }
+
+        private static void PopupTargetPreviewMouseMove(object sender, MouseEventArgs e)
+        {
+            var popup = (sender is FrameworkElement target ? target.GetValue(AutoMovingPopupProperty) : null) as Popup;
+            MovePopup(sender as IInputElement, popup);
+        }
+
+        private static void MovePopup(IInputElement target, Popup popup)
+        {
+            if (popup == null || target == null || popup.PlacementTarget == null)
+            {
+                return;
+            }
+
+            popup.SetCurrentValue(Popup.PlacementProperty, PlacementMode.Relative);
+
+            var hOffsetFromPopup = GetAutoMoveHorizontalOffset(popup);
+            var vOffsetFromPopup = GetAutoMoveVerticalOffset(popup);
+
+            var dpi = DpiHelper.GetDpi(popup);
+
+            Debug.WriteLine(">>dpi       >> x: {0} \t y: {1}", dpi.DpiScaleX, dpi.DpiScaleY);
+
+            var hDPIOffset = DpiHelper.TransformToDeviceX(popup.PlacementTarget, hOffsetFromPopup, dpi.DpiScaleX);
+            var vDPIOffset = DpiHelper.TransformToDeviceY(popup.PlacementTarget, vOffsetFromPopup, dpi.DpiScaleY);
+
+            var position = Mouse.GetPosition(popup.PlacementTarget);
+            var newHorizontalOffset = position.X + hDPIOffset;
+            var newVerticalOffset = position.Y + vDPIOffset;
+
+            var topLeftFromScreen = popup.PlacementTarget.PointToScreen(new Point(0, 0));
+
+#pragma warning disable 618
+            MONITORINFO monitorINFO = null;
+#pragma warning restore 618
+
+            try
+            {
+                monitorINFO = MonitorHelper.GetMonitorInfoFromPoint();
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                Debug.WriteLine("UnauthorizedAccessException occurred getting MONITORINFO: {0}", ex.Message);
+            }
+
+            if (monitorINFO != null)
+            {
+                Debug.WriteLine(">>rcWork    >> w: {0} \t h: {1}", monitorINFO.rcWork.Width, monitorINFO.rcWork.Height);
+                Debug.WriteLine(">>rcMonitor >> w: {0} \t h: {1}", monitorINFO.rcMonitor.Width, monitorINFO.rcMonitor.Height);
+
+                var monitorWorkWidth = Math.Abs(monitorINFO.rcWork.Width);
+                var monitorWorkHeight = Math.Abs(monitorINFO.rcWork.Height);
+
+                topLeftFromScreen.X = -monitorINFO.rcWork.Left + topLeftFromScreen.X;
+                topLeftFromScreen.Y = -monitorINFO.rcWork.Top + topLeftFromScreen.Y;
+
+                var locationX = (int)topLeftFromScreen.X % monitorWorkWidth;
+                var locationY = (int)topLeftFromScreen.Y % monitorWorkHeight;
+
+                var renderDpiWidth = DpiHelper.TransformToDeviceX(popup.PlacementTarget, popup.Child.RenderSize.Width, dpi.DpiScaleX);
+                var rightX = locationX + newHorizontalOffset + renderDpiWidth;
+                if (rightX > monitorWorkWidth)
+                {
+                    newHorizontalOffset = position.X - popup.Child.RenderSize.Width - 0.5 * hDPIOffset;
+                }
+
+                var renderDPIHeight = DpiHelper.TransformToDeviceY(popup.PlacementTarget, popup.Child.RenderSize.Height, dpi.DpiScaleY);
+                var bottomY = locationY + newVerticalOffset + renderDPIHeight;
+                if (bottomY > monitorWorkHeight)
+                {
+                    newVerticalOffset = position.Y - popup.Child.RenderSize.Height - 0.5 * vDPIOffset;
+                }
+
+                Debug.WriteLine(">>Popup   >> bY: {0:F} \t rX: {1:F}", bottomY, rightX);
+
+                popup.SetCurrentValue(Popup.HorizontalOffsetProperty, newHorizontalOffset);
+                popup.SetCurrentValue(Popup.VerticalOffsetProperty, newVerticalOffset);
+
+                Debug.WriteLine(">>offset    >> ho: {0:F} \t vo: {1:F}", popup.HorizontalOffset, popup.VerticalOffset);
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Describe the changes you have made to improve this project**
Introduced a new `Helper-Class` with an `AttachedProperty` similar to the existing `ToolTipAssist`. This allows a `Popup` to follow your curser. 

**How to use**
To use this feature the user has to set at least two things:
1. The `PlacementTarget` of the `Popup`: `PlacementTarget="{Binding [Here goes the binding to the PlacementTarget]}"`
2. The `AttachedProperty`: `controlzEx:PopupAssist.AutoMove="True"`

If the user optionally captures the Mouse on the `PlacementTarget` the `Popup` will follow the mouse even outside of the `PlacementTarget`.

**See it in Action**
![AutoMovingPopup](https://user-images.githubusercontent.com/47110241/71328129-39f1ac00-2512-11ea-9274-6ae085b6568b.gif)

Happy coding and a Merry Christmas
Tim