### PR TITLE
Fix High contrast detection in Theme Manager

### DIFF
--- a/src/ControlzEx/Theming/ThemeManager.cs
+++ b/src/ControlzEx/Theming/ThemeManager.cs
@@ -1358,7 +1358,8 @@ namespace ControlzEx.Theming
 
         private void HandleStaticPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (this.isSyncScheduled == false)
+            if (e.PropertyName == nameof(SystemParameters.HighContrast)
+                && this.isSyncScheduled == false)
             {
                 this.isSyncScheduled = true;
 

--- a/src/ControlzEx/Theming/ThemeManager.cs
+++ b/src/ControlzEx/Theming/ThemeManager.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 namespace ControlzEx.Theming
 {
     using System;
@@ -1336,10 +1336,12 @@ namespace ControlzEx.Theming
                 // Always remove handler first.
                 // That way we prevent double registrations.
                 SystemEvents.UserPreferenceChanged -= this.HandleUserPreferenceChanged;
+                SystemParameters.StaticPropertyChanged -= this.HandleStaticPropertyChanged;
 
                 if (this.themeSyncMode != ThemeSyncMode.DoNotSync)
                 {
                     SystemEvents.UserPreferenceChanged += this.HandleUserPreferenceChanged;
+                    SystemParameters.StaticPropertyChanged += this.HandleStaticPropertyChanged;
                 }
             }
         }
@@ -1348,6 +1350,16 @@ namespace ControlzEx.Theming
         {
             if (e.Category == UserPreferenceCategory.General
                 && this.isSyncScheduled == false)
+            {
+                this.isSyncScheduled = true;
+
+                Dispatcher.CurrentDispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() => this.SyncTheme(this.ThemeSyncMode)));
+            }
+        }
+
+        private void HandleStaticPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (this.isSyncScheduled == false)
             {
                 this.isSyncScheduled = true;
 

--- a/src/ControlzEx/Theming/ThemeManager.cs
+++ b/src/ControlzEx/Theming/ThemeManager.cs
@@ -1,4 +1,4 @@
-#nullable enable
+﻿#nullable enable
 namespace ControlzEx.Theming
 {
     using System;
@@ -1300,9 +1300,8 @@ namespace ControlzEx.Theming
                 baseColor ??= detectedTheme?.BaseColorScheme ?? BaseColorLight;
             }
 
-            var isHighContrast = detectedTheme?.IsHighContrast == true ||
-                                 (syncModeToUse.HasFlag(ThemeSyncMode.SyncWithHighContrast)
-                                    && WindowsThemeHelper.IsHighContrastEnabled());
+            var isHighContrast = syncModeToUse.HasFlag(ThemeSyncMode.SyncWithHighContrast)
+                                 && WindowsThemeHelper.IsHighContrastEnabled();
 
             var accentColorAsString = accentColor.ToString();
 


### PR DESCRIPTION
- Handle SystemParameters.StaticPropertyChanged to get the WIndows HighContrast change too
- Fix changing from HighContrast to non HighContrast theme

Closes #121 

Fix taken from PowerToys [#4007](https://github.com/microsoft/PowerToys/pull/4007/files)
Thx @crutkas for the hint.