### PR TITLE
Try to get the WindowBaseColor in HighContrast mode

### DIFF
--- a/src/ControlzEx.Showcase/MainWindow.xaml
+++ b/src/ControlzEx.Showcase/MainWindow.xaml
@@ -14,7 +14,7 @@
                           Height="600"
                           MinWidth="80"
                           MinHeight="60"
-                          Background="{Binding Source={x:Static SystemColors.WindowBrush}}"
+                          Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"
                           FlowDirection="LeftToRight"
                           GlowBrush="Navy"
                           NonActiveGlowBrush="Crimson"

--- a/src/ControlzEx/Theming/WindowsThemeHelper.cs
+++ b/src/ControlzEx/Theming/WindowsThemeHelper.cs
@@ -41,9 +41,24 @@ namespace ControlzEx.Theming
         [MustUseReturnValue]
         public static string GetWindowsBaseColor()
         {
-            var baseColor = AppsUseLightTheme()
-                ? ThemeManager.BaseColorLight
-                : ThemeManager.BaseColorDark;
+            string baseColor;
+
+            var isHighContrast = IsHighContrastEnabled();
+            if (isHighContrast)
+            {
+                var windowColor = (SystemColors.WindowBrush).Color;
+                var brightness = System.Drawing.Color.FromArgb(windowColor.R, windowColor.G, windowColor.B).GetBrightness();
+
+                baseColor = brightness < .5
+                    ? ThemeManager.BaseColorDark
+                    : ThemeManager.BaseColorLight;
+            }
+            else
+            {
+                baseColor = AppsUseLightTheme()
+                    ? ThemeManager.BaseColorLight
+                    : ThemeManager.BaseColorDark;
+            }
 
             return baseColor;
         }


### PR DESCRIPTION
## Describe the changes you have made to improve this project

- [x] Use the WIndowBrush for getting the WindowBaseColor in HighContrast mode (Use the System.Drawing GetBrightness to decide between dark and light)

<!--
Is your feature request related to a problem? Please describe.
A clear and concise description of what the change is.
-->

## Unit test

- Static classes can not be mocked. So maybe we can do this without any tests.

<!-- If it's possible then make a unit test for your changes. -->

## Additional context

Reason for the PR comes from MahApps: [High contrast theme is not getting applied #3880](https://github.com/MahApps/MahApps.Metro/issues/3880)

**Idea**

In order to fix another issue with HighContrast mode we should first search for an existing theme without an accent color. Because normally there is only one HighContrast theme (like in UWP).

So an app with custom themes should only have two themes, one for light and one for dark if no other will be found.

<!-- Add any other context or screenshots about the feature request here. -->
