### PR TITLE
SyncTheme now works with all flag combinations

### DIFF
--- a/src/ControlzEx.Showcase/App.xaml.cs
+++ b/src/ControlzEx.Showcase/App.xaml.cs
@@ -11,7 +11,7 @@ namespace ControlzEx.Showcase
 
             ThemeManager.Current.ThemeSyncMode = ThemeSyncMode.SyncAll;
 
-            ThemeManager.Current.SyncThemeColorSchemeWithWindowsAccentColor();
+            ThemeManager.Current.SyncTheme();
         }
     }
 }


### PR DESCRIPTION
Without these fixes we switch on single values instead of the presence of single flags.
This also reduces the amount of duplicated code.
Because this also removes some public methods it might be a breaking change for some consumers.