### PR TITLE
Fixed issue with maximizing window on secondary monitors

### DIFF
--- a/src/ControlzEx.Tests/Native/NativeExtensionTests.cs
+++ b/src/ControlzEx.Tests/Native/NativeExtensionTests.cs
@@ -4,7 +4,6 @@
     using global::Windows.Win32.UI.WindowsAndMessaging;
     using NUnit.Framework;
 
-#pragma warning disable CS0618 // Type or member is obsolete
     [TestFixture]
     public class NativeExtensionTests
     {

--- a/src/ControlzEx.Tests/Native/NativeExtensionTests.cs
+++ b/src/ControlzEx.Tests/Native/NativeExtensionTests.cs
@@ -9,7 +9,7 @@
     public class NativeExtensionTests
     {
         [Test]
-        public void RectConvertedFromMonitorPositionIsCorrectSize()
+        public void RectConvertedFromWindowPositionIsCorrectSize()
         {
             const int WIDTH = 800;
             const int HEIGHT = 600;

--- a/src/ControlzEx.Tests/Native/NativeExtensionTests.cs
+++ b/src/ControlzEx.Tests/Native/NativeExtensionTests.cs
@@ -11,38 +11,40 @@
         [Test]
         public void RectConvertedFromMonitorPositionIsCorrectSize()
         {
+            const int WIDTH = 800;
+            const int HEIGHT = 600;
             var windowPos1 = new WINDOWPOS
             {
                 x = 0,
                 y = 0,
-                cx = 800,
-                cy = 600
+                cx = WIDTH,
+                cy = HEIGHT
             };
             var windowPos2 = new WINDOWPOS
             {
                 x = -500,
                 y = -500,
-                cx = 800,
-                cy = 600
+                cx = WIDTH,
+                cy = HEIGHT
             };
             var windowPos3 = new WINDOWPOS
             {
                 x = 5000,
                 y = 5000,
-                cx = 800,
-                cy = 600
+                cx = WIDTH,
+                cy = HEIGHT
             };
 
             var rect1 = windowPos1.ToRECT();
             var rect2 = windowPos2.ToRECT();
             var rect3 = windowPos3.ToRECT();
 
-            Assert.That(rect1.GetWidth(), Is.EqualTo(800));
-            Assert.That(rect1.GetHeight(), Is.EqualTo(600));
-            Assert.That(rect2.GetWidth(), Is.EqualTo(800));
-            Assert.That(rect2.GetHeight(), Is.EqualTo(600));
-            Assert.That(rect3.GetWidth(), Is.EqualTo(800));
-            Assert.That(rect3.GetHeight(), Is.EqualTo(600));
+            Assert.That(rect1.GetWidth(), Is.EqualTo(WIDTH));
+            Assert.That(rect1.GetHeight(), Is.EqualTo(HEIGHT));
+            Assert.That(rect2.GetWidth(), Is.EqualTo(WIDTH));
+            Assert.That(rect2.GetHeight(), Is.EqualTo(HEIGHT));
+            Assert.That(rect3.GetWidth(), Is.EqualTo(WIDTH));
+            Assert.That(rect3.GetHeight(), Is.EqualTo(HEIGHT));
         }
     }
 }

--- a/src/ControlzEx.Tests/Native/NativeExtensionTests.cs
+++ b/src/ControlzEx.Tests/Native/NativeExtensionTests.cs
@@ -1,0 +1,48 @@
+﻿namespace ControlzEx.Tests.Native
+{
+    using global::Windows.Win32;
+    using global::Windows.Win32.UI.WindowsAndMessaging;
+    using NUnit.Framework;
+
+#pragma warning disable CS0618 // Type or member is obsolete
+    [TestFixture]
+    public class NativeExtensionTests
+    {
+        [Test]
+        public void RectConvertedFromMonitorPositionIsCorrectSize()
+        {
+            var windowPos1 = new WINDOWPOS
+            {
+                x = 0,
+                y = 0,
+                cx = 800,
+                cy = 600
+            };
+            var windowPos2 = new WINDOWPOS
+            {
+                x = -500,
+                y = -500,
+                cx = 800,
+                cy = 600
+            };
+            var windowPos3 = new WINDOWPOS
+            {
+                x = 5000,
+                y = 5000,
+                cx = 800,
+                cy = 600
+            };
+
+            var rect1 = windowPos1.ToRECT();
+            var rect2 = windowPos2.ToRECT();
+            var rect3 = windowPos3.ToRECT();
+
+            Assert.That(rect1.GetWidth(), Is.EqualTo(800));
+            Assert.That(rect1.GetHeight(), Is.EqualTo(600));
+            Assert.That(rect2.GetWidth(), Is.EqualTo(800));
+            Assert.That(rect2.GetHeight(), Is.EqualTo(600));
+            Assert.That(rect3.GetWidth(), Is.EqualTo(800));
+            Assert.That(rect3.GetHeight(), Is.EqualTo(600));
+        }
+    }
+}

--- a/src/ControlzEx/Native/PInvokeExtensions.cs
+++ b/src/ControlzEx/Native/PInvokeExtensions.cs
@@ -58,8 +58,8 @@ namespace Windows.Win32
             {
                 left = windowpos.x,
                 top = windowpos.y,
-                right = (int)windowpos.cx - windowpos.x,
-                bottom = (int)windowpos.cy - windowpos.y
+                right = windowpos.x + windowpos.cx,
+                bottom = windowpos.y + windowpos.cy
             };
         }
     }


### PR DESCRIPTION
## Describe the changes you have made to improve this project

This fixes an issue with maximizing a window on a monitor to the left of (or above) the main monitor. The root cause was the calculation of the `right` and `bottom` properties in the `ToRECT` method. This wrong calculation resulted in `MonitorFromWindowPosOrWindow` returning the wrong monitor, which in turn made `_HandleNCCALCSIZE` not work correctly.

## Unit test

Added test called `RectConvertedFromWindowPositionIsCorrectSize`.

## Additional context

Before the fix
![before](https://user-images.githubusercontent.com/1404846/176158066-6af4694a-8f8a-441f-b06f-c6ea1cba7f92.png)

After the fix
![after](https://user-images.githubusercontent.com/1404846/176158083-aeb72d87-8d90-416c-a8ae-e506dcd6e4cc.png)
