### PR TITLE
We don't have to add WS_CAPTION anymore

### DIFF
--- a/src/ControlzEx/Behaviors/WindowChrome/WindowChromeBehavior.MessageHandling.cs
+++ b/src/ControlzEx/Behaviors/WindowChrome/WindowChromeBehavior.MessageHandling.cs
@@ -777,12 +777,12 @@ namespace ControlzEx.Behaviors
                     && this._GetHwndState() == WindowState.Maximized)
                 {
                     structure.styleNew |= (uint)WINDOW_STYLE.WS_OVERLAPPED;
-                    structure.styleNew &= (uint)~WINDOW_STYLE.WS_CAPTION;
+                    //structure.styleNew &= (uint)~WINDOW_STYLE.WS_CAPTION;
                     //structure.styleNew &= (uint)~WINDOW_STYLE.WS_SYSMENU; // todo: must be removed for mica effect
                 }
                 else
                 {
-                    structure.styleNew |= (uint)(WINDOW_STYLE.WS_OVERLAPPED | WINDOW_STYLE.WS_CAPTION);
+                    //structure.styleNew |= (uint)(WINDOW_STYLE.WS_OVERLAPPED | WINDOW_STYLE.WS_CAPTION);
                     //structure.styleNew &= (uint)~WINDOW_STYLE.WS_SYSMENU; // todo: must be removed for mica effect
                 }
 
@@ -957,7 +957,7 @@ namespace ControlzEx.Behaviors
             else
             {
                 //this._ModifyStyle(WINDOW_STYLE.WS_SYSMENU, WINDOW_STYLE.WS_CAPTION);
-                this._ModifyStyle(0, WINDOW_STYLE.WS_CAPTION); // todo: mica
+                //this._ModifyStyle(0, WINDOW_STYLE.WS_CAPTION); // todo: mica
             }
         }
 


### PR DESCRIPTION
Since we now support different window styles, we don't have to set WS_CAPTION anymore.

I we continue to add WS_CAPTION, a window is maximized and the UI thread is unresponsive the window gets resized to a fullscreen window by windows which causes the taskbar to be obstructed by the window.
That's of course undesired behavior.

@punker76 This also fixes #167.
