### PR TITLE
Fixing issues when taking screenshots

### DIFF
--- a/src/ControlzEx.Showcase/App.xaml
+++ b/src/ControlzEx.Showcase/App.xaml
@@ -30,7 +30,8 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type controlzEx:WindowChromeWindow}">
-                            <Grid Background="{TemplateBinding Background}">
+                            <Grid Background="{TemplateBinding Background}"
+                                  Margin="{TemplateBinding Padding}">
                                 <AdornerDecorator>
                                     <ContentPresenter />
                                 </AdornerDecorator>

--- a/src/ControlzEx/Controls/GlowWindow.cs
+++ b/src/ControlzEx/Controls/GlowWindow.cs
@@ -1254,6 +1254,9 @@ namespace ControlzEx.Controls.Internal
                 return;
             }
 
+            // We have to position the glow one px below the top to allow the border/glow to be visible on screenshots
+            lpRect.top += 1;
+
             switch (this.orientation)
             {
                 case Dock.Left:

--- a/src/ControlzEx/WindowChromeWindow.cs
+++ b/src/ControlzEx/WindowChromeWindow.cs
@@ -13,6 +13,9 @@ namespace ControlzEx
     [PublicAPI]
     public partial class WindowChromeWindow : Window
     {
+        private static readonly object defaultContentPadding = new Thickness(0, 1, 0, 0);
+        private static readonly object emptyContentPadding = default(Thickness);
+
         static WindowChromeWindow()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(WindowChromeWindow), new FrameworkPropertyMetadata(typeof(WindowChromeWindow)));
@@ -156,7 +159,12 @@ namespace ControlzEx
         /// <summary>
         /// <see cref="DependencyProperty"/> for <see cref="GlowColor"/>.
         /// </summary>
-        public static readonly DependencyProperty GlowColorProperty = DependencyProperty.Register(nameof(GlowColor), typeof(Color?), typeof(WindowChromeWindow), new PropertyMetadata(null));
+        public static readonly DependencyProperty GlowColorProperty = DependencyProperty.Register(nameof(GlowColor), typeof(Color?), typeof(WindowChromeWindow), new PropertyMetadata(null, OnGlowColorChanged));
+
+        private static void OnGlowColorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((WindowChromeWindow)d).UpdatePadding();
+        }
 
         /// <summary>
         /// Gets or sets a brush which is used as the glow when the window is active.
@@ -170,7 +178,12 @@ namespace ControlzEx
         /// <summary>
         /// <see cref="DependencyProperty"/> for <see cref="NonActiveGlowColor"/>.
         /// </summary>
-        public static readonly DependencyProperty NonActiveGlowColorProperty = DependencyProperty.Register(nameof(NonActiveGlowColor), typeof(Color?), typeof(WindowChromeWindow), new PropertyMetadata(null));
+        public static readonly DependencyProperty NonActiveGlowColorProperty = DependencyProperty.Register(nameof(NonActiveGlowColor), typeof(Color?), typeof(WindowChromeWindow), new PropertyMetadata(null, OnNonActiveGlowColorChanged));
+
+        private static void OnNonActiveGlowColorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            ((WindowChromeWindow)d).UpdatePadding();
+        }
 
         /// <summary>
         /// Gets or sets a brush which is used as the glow when the window is not active.
@@ -249,6 +262,37 @@ namespace ControlzEx
         {
             get => (WindowCornerPreference)this.GetValue(CornerPreferenceProperty);
             set => this.SetValue(CornerPreferenceProperty, value);
+        }
+
+        protected override void OnActivated(EventArgs e)
+        {
+            base.OnActivated(e);
+            this.UpdatePadding();
+        }
+
+        protected override void OnDeactivated(EventArgs e)
+        {
+            base.OnDeactivated(e);
+            this.UpdatePadding();
+        }
+
+        protected virtual void UpdatePadding()
+        {
+            if (this.IsActive
+                && this.GlowColor is not null)
+            {
+                this.SetCurrentValue(PaddingProperty, defaultContentPadding);
+                return;
+            }
+
+            if (this.IsActive == false
+                && this.NonActiveGlowColor is not null)
+            {
+                this.SetCurrentValue(PaddingProperty, defaultContentPadding);
+                return;
+            }
+
+            this.SetCurrentValue(PaddingProperty, emptyContentPadding);
         }
     }
 }


### PR DESCRIPTION
Second try. ;-)

This requires every consumer to set a margin/padding on the content of the window when using any glow color.

This also fixes another issue i noticed while building this fix.
On Windows 11 when using the default window border the content misses one pixel on the top side.
That's best visible in the showcase applications window button where the top border is missing without using a margin/padding on the window content.