### PR TITLE
Reduced nesting levels through block-scoped `using`s

### DIFF
--- a/src/ControlzEx.Tests/Helpers/GlowWindowBitmapGeneratorTest.cs
+++ b/src/ControlzEx.Tests/Helpers/GlowWindowBitmapGeneratorTest.cs
@@ -27,10 +27,9 @@ namespace ControlzEx.Tests.Helpers
 
                 var fileName = Path.Combine(directory, $"{value}.png");
 
-                using (var stream = File.Create(fileName))
-                {
-                    encoder.Save(stream);
-                }
+                using var stream = File.Create(fileName);
+
+                encoder.Save(stream);
             }
         }
     }

--- a/src/ControlzEx.Tests/Theming/ThemeManagerTests.cs
+++ b/src/ControlzEx.Tests/Theming/ThemeManagerTests.cs
@@ -34,11 +34,9 @@ namespace ControlzEx.Tests.Theming
         [Test]
         public void ChangeThemeForWindowShouldThrowArgumentNullException()
         {
-            using (var window = new TestWindow())
-            {
-                Assert.Throws<ArgumentNullException>(() => this.testThemeManager.ChangeTheme((Window)null, this.testThemeManager.GetTheme("Light.Red")));
-                Assert.Throws<ArgumentNullException>(() => this.testThemeManager.ChangeTheme(Application.Current.MainWindow, this.testThemeManager.GetTheme("UnknownTheme")));
-            }
+            using var window = new TestWindow();
+            Assert.Throws<ArgumentNullException>(() => this.testThemeManager.ChangeTheme((Window)null, this.testThemeManager.GetTheme("Light.Red")));
+            Assert.Throws<ArgumentNullException>(() => this.testThemeManager.ChangeTheme(Application.Current.MainWindow, this.testThemeManager.GetTheme("UnknownTheme")));
         }
 
         [Test]
@@ -105,14 +103,13 @@ namespace ControlzEx.Tests.Theming
         [Test]
         public void ChangingAppThemeChangesWindowTheme()
         {
-            using (var window = new TestWindow())
-            {
-                var expectedTheme = this.testThemeManager.GetTheme("Dark.Teal");
-                this.testThemeManager.ChangeTheme(Application.Current, expectedTheme);
+            using var window = new TestWindow();
 
-                Assert.That(this.testThemeManager.DetectTheme(Application.Current), Is.EqualTo(expectedTheme));
-                Assert.That(this.testThemeManager.DetectTheme(window), Is.EqualTo(expectedTheme));
-            }
+            var expectedTheme = this.testThemeManager.GetTheme("Dark.Teal");
+            this.testThemeManager.ChangeTheme(Application.Current, expectedTheme);
+
+            Assert.That(this.testThemeManager.DetectTheme(Application.Current), Is.EqualTo(expectedTheme));
+            Assert.That(this.testThemeManager.DetectTheme(window), Is.EqualTo(expectedTheme));
         }
 
         [Test]
@@ -131,16 +128,15 @@ namespace ControlzEx.Tests.Theming
             }
 
             {
-                using (var window = new TestWindow())
-                {
-                    var currentTheme = this.testThemeManager.DetectTheme(window);
+                using var window = new TestWindow();
 
-                    Assert.That(currentTheme, Is.Not.Null);
-                    this.testThemeManager.ChangeThemeBaseColor(window, this.testThemeManager.GetInverseTheme(currentTheme).BaseColorScheme);
+                var currentTheme = this.testThemeManager.DetectTheme(window);
 
-                    Assert.That(this.testThemeManager.DetectTheme(window).BaseColorScheme, Is.Not.EqualTo(currentTheme.BaseColorScheme));
-                    Assert.That(this.testThemeManager.DetectTheme(window).ColorScheme, Is.EqualTo(currentTheme.ColorScheme));
-                }
+                Assert.That(currentTheme, Is.Not.Null);
+                this.testThemeManager.ChangeThemeBaseColor(window, this.testThemeManager.GetInverseTheme(currentTheme).BaseColorScheme);
+
+                Assert.That(this.testThemeManager.DetectTheme(window).BaseColorScheme, Is.Not.EqualTo(currentTheme.BaseColorScheme));
+                Assert.That(this.testThemeManager.DetectTheme(window).ColorScheme, Is.EqualTo(currentTheme.ColorScheme));
             }
 
             {
@@ -172,16 +168,15 @@ namespace ControlzEx.Tests.Theming
             }
 
             {
-                using (var window = new TestWindow())
-                {
-                    var currentTheme = this.testThemeManager.DetectTheme(window);
+                using var window = new TestWindow();
 
-                    Assert.That(currentTheme, Is.Not.Null);
-                    this.testThemeManager.ChangeThemeColorScheme(window, "Green");
+                var currentTheme = this.testThemeManager.DetectTheme(window);
 
-                    Assert.That(this.testThemeManager.DetectTheme(window).BaseColorScheme, Is.EqualTo(currentTheme.BaseColorScheme));
-                    Assert.That(this.testThemeManager.DetectTheme(window).ColorScheme, Is.EqualTo("Green"));
-                }
+                Assert.That(currentTheme, Is.Not.Null);
+                this.testThemeManager.ChangeThemeColorScheme(window, "Green");
+
+                Assert.That(this.testThemeManager.DetectTheme(window).BaseColorScheme, Is.EqualTo(currentTheme.BaseColorScheme));
+                Assert.That(this.testThemeManager.DetectTheme(window).ColorScheme, Is.EqualTo("Green"));
             }
 
             {
@@ -215,16 +210,15 @@ namespace ControlzEx.Tests.Theming
             }
 
             {
-                using (var window = new TestWindow())
-                {
-                    var currentTheme = this.testThemeManager.DetectTheme(window);
+                using var window = new TestWindow();
 
-                    Assert.That(currentTheme, Is.Not.Null);
-                    this.testThemeManager.ChangeTheme(window, ThemeManager.BaseColorLight, "Green");
+                var currentTheme = this.testThemeManager.DetectTheme(window);
 
-                    Assert.That(this.testThemeManager.DetectTheme(window).BaseColorScheme, Is.EqualTo(ThemeManager.BaseColorLight));
-                    Assert.That(this.testThemeManager.DetectTheme(window).ColorScheme, Is.EqualTo("Green"));
-                }
+                Assert.That(currentTheme, Is.Not.Null);
+                this.testThemeManager.ChangeTheme(window, ThemeManager.BaseColorLight, "Green");
+
+                Assert.That(this.testThemeManager.DetectTheme(window).BaseColorScheme, Is.EqualTo(ThemeManager.BaseColorLight));
+                Assert.That(this.testThemeManager.DetectTheme(window).ColorScheme, Is.EqualTo("Green"));
             }
 
             {

--- a/src/ControlzEx/Theming/LibraryThemeProvider.cs
+++ b/src/ControlzEx/Theming/LibraryThemeProvider.cs
@@ -44,18 +44,16 @@ namespace ControlzEx.Theming
                     continue;
                 }
 
-                using (var stream = this.assembly.GetManifestResourceStream(resourceName))
-                {
-                    if (stream is null)
-                    {
-                        continue;
-                    }
+                using var stream = this.assembly.GetManifestResourceStream(resourceName);
 
-                    using (var reader = new StreamReader(stream))
-                    {
-                        return reader.ReadToEnd();
-                    }
+                if (stream is null)
+                {
+                    continue;
                 }
+
+                using var reader = new StreamReader(stream);
+
+                return reader.ReadToEnd();
             }
 
             return null;
@@ -70,18 +68,16 @@ namespace ControlzEx.Theming
                     continue;
                 }
 
-                using (var stream = this.assembly.GetManifestResourceStream(resourceName))
-                {
-                    if (stream is null)
-                    {
-                        continue;
-                    }
+                using var stream = this.assembly.GetManifestResourceStream(resourceName);
 
-                    using (var reader = new StreamReader(stream))
-                    {
-                        return reader.ReadToEnd();
-                    }
+                if (stream is null)
+                {
+                    continue;
                 }
+
+                using var reader = new StreamReader(stream);
+
+                return reader.ReadToEnd();
             }
 
             return null;
@@ -139,16 +135,15 @@ namespace ControlzEx.Theming
                     continue;
                 }
 
-                using (var reader = new ResourceReader(resourceStream))
-                {
-                    foreach (var dictionaryEntry in reader.OfType<DictionaryEntry>())
-                    {
-                        var theme = this.GetLibraryTheme(dictionaryEntry);
+                using var reader = new ResourceReader(resourceStream);
 
-                        if (theme is not null)
-                        {
-                            yield return theme;
-                        }
+                foreach (var dictionaryEntry in reader.OfType<DictionaryEntry>())
+                {
+                    var theme = this.GetLibraryTheme(dictionaryEntry);
+
+                    if (theme is not null)
+                    {
+                        yield return theme;
                     }
                 }
             }


### PR DESCRIPTION
For better readability