### PR TITLE
Handle issues with cleartype and backdrop

### DIFF
--- a/src/ControlzEx.Showcase/MainWindow.xaml
+++ b/src/ControlzEx.Showcase/MainWindow.xaml
@@ -25,7 +25,7 @@
                                WindowState="Normal"
                                SizeToContent="Manual"
                                Topmost="False"
-                               controlzEx:WindowBackdropManager.BackdropType="Mica"
+                               controlzEx:WindowBackdropManager.BackdropType="None"
                                mc:Ignorable="d">
     <controlzEx:WindowChromeWindow.Resources>
         <ObjectDataProvider x:Key="ResizeModeEnumValues"

--- a/src/ControlzEx.Showcase/Themes/Controls.xaml
+++ b/src/ControlzEx.Showcase/Themes/Controls.xaml
@@ -1,18 +1,16 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:controlzex="urn:controlzex">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Style TargetType="AccessText">
         <Setter Property="OverridesDefaultStyle" Value="True" />
     </Style>
 
     <Style TargetType="Label">
         <Setter Property="OverridesDefaultStyle" Value="True" />
-        <Setter Property="Padding"
-                Value="5" />
-        <Setter Property="HorizontalContentAlignment"
-                Value="Left" />
-        <Setter Property="VerticalContentAlignment"
-                Value="Top" />
+        <Setter Property="Padding" Value="5" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="VerticalContentAlignment" Value="Top" />
+        <Setter Property="RenderOptions.ClearTypeHint" Value="Enabled" />
+        <Setter Property="TextOptions.TextFormattingMode" Value="Display" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Label}">
@@ -297,8 +295,8 @@
                 <ControlTemplate TargetType="{x:Type ComboBoxItem}">
                     <Grid>
                         <Border x:Name="ContentBorder"
-                                Margin="{TemplateBinding Margin}"
-                                Padding="0"
+                                Background="{TemplateBinding Background}"
+                                Padding="{TemplateBinding Margin}"
                                 VerticalAlignment="Stretch"
                                 CornerRadius="{TemplateBinding Border.CornerRadius}"
                                 SnapsToDevicePixels="True">
@@ -419,10 +417,11 @@
                                     </Grid>
                                 </Grid>
                                 <Popup x:Name="Popup"
-                                       controlzex:PopupBackdropManager.BackdropType="AcrylicBlurbehind"
+                                       RenderOptions.ClearTypeHint="Enabled"
+                                       TextOptions.TextFormattingMode="Display"
                                        MinWidth="{TemplateBinding ActualWidth}"
                                        VerticalAlignment="Center"
-                                       AllowsTransparency="True"
+                                       AllowsTransparency="False"
                                        Focusable="False"
                                        IsOpen="{TemplateBinding IsDropDownOpen}"
                                        Placement="{TemplateBinding Popup.Placement}"

--- a/src/ControlzEx/Theming/WindowBackdropManager.cs
+++ b/src/ControlzEx/Theming/WindowBackdropManager.cs
@@ -3,7 +3,7 @@ namespace ControlzEx.Theming
     using System;
     using System.Windows;
     using System.Windows.Interop;
-    using ControlzEx.Helpers;
+    using System.Windows.Media;
     using ControlzEx.Internal;
 
     public class WindowBackdropManager : DependencyObject
@@ -58,25 +58,34 @@ namespace ControlzEx.Theming
                 return true;
             }
 
-            if (target is { AllowsTransparency: true })
-            {
-                SetCurrentBackdropType(target, WindowBackdropType.None);
-                return false;
-            }
-
-            if (FeatureSupport.IsWindowBackdropSupported is false)
-            {
-                SetCurrentBackdropType(target, WindowBackdropType.None);
-                return false;
-            }
-
             if (PresentationSource.FromVisual(target) is HwndSource hwndSource)
             {
+                if (hwndSource.CompositionTarget is { } compositionTarget)
+                {
+                    compositionTarget.BackgroundColor = windowBackdropType != WindowBackdropType.None
+                        ? Colors.Transparent
+                        : Color.FromRgb(0, 0, 0); // same value as in HwndTarget
+                }
+
+                if (target is { AllowsTransparency: true })
+                {
+                    SetCurrentBackdropType(target, WindowBackdropType.None);
+                    return false;
+                }
+
+                if (FeatureSupport.IsWindowBackdropSupported is false)
+                {
+                    SetCurrentBackdropType(target, WindowBackdropType.None);
+                    return false;
+                }
+
                 var handle = hwndSource.Handle;
 
                 var result = UpdateBackdrop(handle, windowBackdropType);
 
-                SetCurrentBackdropType(target, result ? windowBackdropType : WindowBackdropType.None);
+                SetCurrentBackdropType(target, result
+                                           ? windowBackdropType
+                                           : WindowBackdropType.None);
 
                 return result;
             }

--- a/src/ControlzEx/WindowChromeWindow.cs
+++ b/src/ControlzEx/WindowChromeWindow.cs
@@ -7,14 +7,12 @@ namespace ControlzEx
     using System.Windows.Interop;
     using System.Windows.Media;
     using ControlzEx.Behaviors;
-    using ControlzEx.Helpers;
     using ControlzEx.Internal;
     using ControlzEx.Internal.KnownBoxes;
     using ControlzEx.Native;
     using ControlzEx.Theming;
     using JetBrains.Annotations;
     using Microsoft.Xaml.Behaviors;
-    using Windows.Win32;
     using Windows.Win32.Foundation;
     using Windows.Win32.Graphics.Dwm;
     using COLORREF = Windows.Win32.COLORREF;
@@ -41,12 +39,6 @@ namespace ControlzEx
             base.OnSourceInitialized(e);
 
             this.windowHandle = new HWND(new WindowInteropHelper(this).Handle);
-            this.hwndSource = HwndSource.FromHwnd(this.windowHandle);
-
-            if (this.hwndSource?.CompositionTarget is { } compositionTarget)
-            {
-                compositionTarget.BackgroundColor = Colors.Transparent;
-            }
 
             this.UpdateCaptionColor();
 

--- a/src/ControlzEx/WindowChromeWindow.cs
+++ b/src/ControlzEx/WindowChromeWindow.cs
@@ -26,6 +26,9 @@ namespace ControlzEx
         static WindowChromeWindow()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(WindowChromeWindow), new FrameworkPropertyMetadata(typeof(WindowChromeWindow)));
+
+            RenderOptions.ClearTypeHintProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata { DefaultValue = ClearTypeHint.Enabled });
+            TextOptions.TextFormattingModeProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata { DefaultValue = TextFormattingMode.Display });
         }
 
         public WindowChromeWindow()


### PR DESCRIPTION
## Describe the changes you have made to improve this project

- set the BackgroundColor for CompositionTarget only to transparent when BackdropType is not None
- set RenderOptions.ClearTypeHint and TextOptions.TextFormattingMode for Window and Combobox to force ClearType
