### PR TITLE
Remove workaround fro already added member

### DIFF
--- a/src/ControlzEx/Internal/DWMHelper.cs
+++ b/src/ControlzEx/Internal/DWMHelper.cs
@@ -67,8 +67,7 @@ namespace ControlzEx.Internal
 
         public static bool SetBackdropType(IntPtr hWnd, WindowBackdropType windowBackdropType)
         {
-            const DWMWINDOWATTRIBUTE DWMWA_SYSTEMBACKDROP_TYPE = (DWMWINDOWATTRIBUTE)38;
-            return SetWindowAttributeValue(hWnd, DWMWA_SYSTEMBACKDROP_TYPE, (int)windowBackdropType);
+            return SetWindowAttributeValue(hWnd, DWMWINDOWATTRIBUTE.DWMWA_SYSTEMBACKDROP_TYPE, (int)windowBackdropType);
         }
     }
 }


### PR DESCRIPTION
Removed workaround for missing native interop member since the underlying issue has already been resolved